### PR TITLE
fix dead links

### DIFF
--- a/r/cmp.tmpl
+++ b/r/cmp.tmpl
@@ -115,7 +115,7 @@ Click on the fileformats name to discover more.
 <tr> <td class="tdleft">Process attaching</td>         <td class='y'>yes</td> <td class='y'>yes</td> <td class='y'>yes</td> </tr>
 <tr> <td class="tdleft">Remote debugging</td>          <td class='y'>yes</td> <td class='y'>yes</td> <td class='y'>yes</td> </tr>
 <tr> <td class="tdleft">Tracing</td>                   <td class='y'>yes</td> <td class='y'>yes</td> <td class='n'>no </td> </tr>
-<tr> <td class="tdleft">Emulation</td>                 <td class='y'><a href='https://github.com/radare/radare2/wiki/ESIL'>yes</a></td> <td class='y'><a href='http://www.idabook.com/x86emu/'>plugin</a></td> <td class='n'>no </td> </tr>
+<tr> <td class="tdleft">Emulation</td>                 <td class='y'><a href='https://radare.gitbooks.io/radare2book/content/esil.html'>yes</a></td> <td class='y'><a href='http://www.idabook.com/x86emu/'>plugin</a></td> <td class='n'>no </td> </tr>
 </tbody> </table>
 
 <table class='comparison'>
@@ -172,7 +172,7 @@ Click on the fileformats name to discover more.
 <thead>
 <tr> <td class="tdleft">Project management</td>        <td>r2</td>       <td>IDA</td>           <td>Hopper</td> </tr>
 </thead> <tbody>
-<tr> <td class="tdleft">Collaborative work</td>        <td class='w'>wip</td> <td class='w'><a href='https://crowdre.crowdstrike.com/sign-in'>plugin</a></td> <td class='n'>no </td> </tr>
+<tr> <td class="tdleft">Collaborative work</td>        <td class='w'>wip</td> <td class='w'><a href='http://www.idabook.com/collabreate/'>plugin</a></td> <td class='n'>no </td> </tr>
 <tr> <td class="tdleft">Saving and exporting</td>      <td class='y'>yes</td> <td class='y'>yes</td> <td class='y'>yes</td> </tr>
 </tbody> </table>
 


### PR DESCRIPTION
ESIL link pointed to a dead wiki page, and crowre is no longer. 

Linked to Eagle's collabreate instead for IDA collaboration (though it's pretty dated, I think it's the only current working collaboration for IDA until Marcus releases his Sol[IDA]rity plugin).