### PR TITLE
Update Windows download links

### DIFF
--- a/r/down.tmpl
+++ b/r/down.tmpl
@@ -27,14 +27,13 @@ Source
 </div>
 
 <div class="icon">
-<a title="windows" href="http://radare.mikelloc.com/get/<{$radare2_version}>/radare2-w32-<{$radare2_w32_version}>.zip">
+<a title="windows" href="http://radare.mikelloc.com/get/<{$radare2_version}>/radare2_installer-msvc_32-<{$radare2_w32_version}>.exe">
 <img width=64 height=64 src="img/os-windows.png">
 <br>
 W32
 </a>
-<a title="windows" href="http://bin.rada.re/radare2-w32-<{$radare2_w32_git_version}>.zip">
-
-/ Git
+<a title="windows" href="http://radare.mikelloc.com/get/<{$radare2_version}>/radare2_installer-msvc_64-<{$radare2_w32_version}>.exe">
+/ W64
 </a>
 </div>
 


### PR DESCRIPTION
So it now points to the w32/w64 installers.