### PR TITLE
Fix url to 33c3 talk - radare demystified

### DIFF
--- a/r/talks.tmpl
+++ b/r/talks.tmpl
@@ -17,7 +17,7 @@
 - Wa-r2-Con [PDF](/get/war2con2016.pdf)
 - r2con2016 [PDF](https://github.com/radareorg/r2con) [VID](https://www.youtube.com/watch?v=QVjrqlo5A9g&list=PLjIhlLNy_Y9O62rjwYD48pVER0EVh1-aU)
 - OverDriveCon [PDF](https://radare.org/get/rwr2-overdrive-2016.pdf)
-- 33C3 [PDF](/get/33c3-r2demystified.pdf) [VID](https://www.youtube.com/watch?v=afPZG6XC-KU) [TGZ](/get/radare2-demystified-demos.tar.gz)
+- 33C3 [PDF](/get/33c3-r2demystified.pdf) [VID](https://www.youtube.com/watch?v=fnpBy3wWabA) [TGZ](/get/radare2-demystified-demos.tar.gz)
 
 <{/markdown}>
 </div>


### PR DESCRIPTION
Old  video is no longer available because the YouTube account associated with this video has been terminated.